### PR TITLE
Support go 1.8

### DIFF
--- a/gen.sh
+++ b/gen.sh
@@ -1,0 +1,11 @@
+#/bin/sh
+
+set -ex
+
+if [ ! -z "$1" ]; then GOROOT=$1; fi
+
+cp -f $GOROOT/src/runtime/go_tls.h go_tls.h
+WORK=$(go build -a -x -work runtime 2>&1|sed -e 's/^WORK=//g; t; d;')
+cp $WORK/runtime/_obj/go_asm.h ./
+rm -rf $WORK
+

--- a/goid.go
+++ b/goid.go
@@ -2,7 +2,7 @@
 // Run `go generate` before use.
 package goid
 
-//go:generate cp -f $GOROOT/src/runtime/zasm_linux_amd64.h zasm_linux_amd64.h
+//go:generate sh gen.sh $GOROOT
 
 // GoID returns the current goroutine id.
 // It exactly matches goroutine id of the stack trace.

--- a/goid_amd64.s
+++ b/goid_amd64.s
@@ -1,5 +1,8 @@
+#include "go_asm.h"
+#include "go_tls.h"
 #include "textflag.h"
-#include "zasm_GOOS_GOARCH.h"
+
+// see also: https://golang.org/doc/asm
 
 // func GoID() int64
 TEXT ·GoID(SB),NOSPLIT,$0-8


### PR DESCRIPTION
* Go 1.8をサポート
* Go 1.6ぐらい? から、Goroutineの内部構造体である `struct g` がC言語のコードから `runtime2.go` に移ったため、`zasm_linux_amd64.h` では `g_goid` が定義されなくなった
* そこで、`go generate` 時に `runtime`パッケージをビルドし、ビルド中に生成される`go_asm.h`を取り出すことで、 `g_goid` マクロを入手した

`go_asm.h`

```c
// ...
#define g_goid 192 
```

`go_tls.h`

```c
// ...
#define get_tls(r)      MOVQ TLS, r
#define g(r)    0(r)(TLS*1)
```
